### PR TITLE
Moved -lswresample to be last library to avoid build errors

### DIFF
--- a/ffmpegViewer/ffmpegViewer.pro
+++ b/ffmpegViewer/ffmpegViewer.pro
@@ -18,7 +18,7 @@ LIBS += -L$$(EPICS_BASE)/lib/linux-x86_64 -lca
 # ffmpeg stuff
 INCLUDEPATH += $$(FFMPEG_PREFIX)/include
 QMAKE_RPATHDIR += $$(FFMPEG_PREFIX)/lib
-LIBS += -L$$(FFMPEG_PREFIX)/lib -lswresample -lavfilter -lavdevice -lavformat -lavcodec -lavutil -lbz2 -lswscale
+LIBS += -L$$(FFMPEG_PREFIX)/lib -lavfilter -lavdevice -lavformat -lavcodec -lavutil -lbz2 -lswscale -lswresample
 DEFINES += __STDC_CONSTANT_MACROS
 
 # xvideo stuff

--- a/ffmpegWebcam4/ffmpegWebcam4.pro
+++ b/ffmpegWebcam4/ffmpegWebcam4.pro
@@ -10,7 +10,7 @@ QMAKE_CLEAN += $$TARGET
 # ffmpeg stuff
 INCLUDEPATH += $$(FFMPEG_PREFIX)/include
 QMAKE_RPATHDIR += $$(FFMPEG_PREFIX)/lib
-LIBS += -L$$(FFMPEG_PREFIX)/lib -lswresample -lavfilter -lavdevice -lavformat -lavcodec -lavutil -lbz2 -lswscale
+LIBS += -L$$(FFMPEG_PREFIX)/lib -lavfilter -lavdevice -lavformat -lavcodec -lavutil -lbz2 -lswscale -lswresample
 DEFINES += __STDC_CONSTANT_MACROS
 
 # xvideo stuff


### PR DESCRIPTION
I had to move the -lswresample to be the last library linked or I got unresolved symbols.
